### PR TITLE
Re-wrote Readme to explain better the expected payload for webhooks an…

### DIFF
--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -3,6 +3,7 @@ import { connectToDatabase } from '@/lib/mongodb'
 import { FormDefinition, DEFAULT_FORMS } from '@/models/form'
 import { getIntegrationClient } from '@/lib/integration-app-client'
 import { getStoredAuth, type AuthCustomer } from '@/lib/auth'
+import { RECORD_ACTIONS } from '@/lib/constants'
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
@@ -15,11 +16,11 @@ export async function GET(request: Request) {
   await connectToDatabase()
 
   // Ensure default forms exist for this customer
-  const defaultForms = [
-    { formId: 'contacts', formTitle: 'Contacts', type: 'default' },
-    { formId: 'companies', formTitle: 'Companies', type: 'default' },
-    { formId: 'tasks', formTitle: 'Tasks', type: 'default' }
-  ];
+  const defaultForms = RECORD_ACTIONS.map(action => ({
+    formId: action.key.replace('get-', ''),
+    formTitle: action.name,
+    type: action.type
+  }))
 
   await Promise.all(
     defaultForms.map(async (defaultForm) => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,13 +5,8 @@ export const RECORD_ACTIONS = [
     type: 'default'
   },
   {
-    key: 'get-companies',
-    name: 'Companies',
-    type: 'default'
-  },
-  {
-    key: 'get-tasks',
-    name: 'Tasks',
+    key: 'get-payments',
+    name: 'Payments',
     type: 'default'
   }
 ] as const;

--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { RECORD_ACTIONS } from '@/lib/constants'
 
 const formDefinitionSchema = new mongoose.Schema({
   customerId: { type: String, required: true },
@@ -17,25 +18,8 @@ export const FormDefinition = mongoose.models.FormDefinition ||
   mongoose.model('FormDefinition', formDefinitionSchema)
 
 // Default forms to be seeded
-export const DEFAULT_FORMS = [
-  { 
-    formId: 'contacts', 
-    formTitle: 'Contacts',
-    type: 'default'
-  },
-  { 
-    formId: 'leads', 
-    formTitle: 'Leads',
-    type: 'default'
-  },
-  { 
-    formId: 'companies', 
-    formTitle: 'Companies',
-    type: 'default'
-  },
-  { 
-    formId: 'deals', 
-    formTitle: 'Deals',
-    type: 'default'
-  }
-] as const 
+export const DEFAULT_FORMS = RECORD_ACTIONS.map(action => ({
+  formId: action.key.replace('get-', ''),
+  formTitle: action.name,
+  type: action.type
+})) 


### PR DESCRIPTION
…d the path. Unified constants logic accross all uses

## Summary by Sourcery

Generate default form definitions from a central RECORD_ACTIONS constant, refactor the form configuration page to unify connection, data source, and field mapping logic for both default and custom forms, update UI labels, and expand the README with comprehensive webhook endpoint documentation.

Enhancements:
- Drive default form seeding and API form list from the RECORD_ACTIONS constant instead of hard-coded arrays
- Refactor FormsPage to handle default and custom forms uniformly by computing dataSourceName, instanceConfig, and falling back to the first integration connection
- Update record configuration UI titles and descriptions to clarify data collection and field mapping
- Update RECORD_ACTIONS to replace outdated entries with a new ‘Payments’ record action

Documentation:
- Add detailed `/api/webhooks` endpoint documentation in the README, including payload schema, response format, behavior, and example usage